### PR TITLE
Changed Typo commmunity_nme to community_name in arubaoss_snmp.py

### DIFF
--- a/plugins/modules/arubaoss_snmp.py
+++ b/plugins/modules/arubaoss_snmp.py
@@ -33,7 +33,7 @@ description:
     - "This implements rest api's which configure snmp on device"
 
 options:
-    commmunity_nme:
+    community_name:
         description:
             - snmp community name. Required when configuring community
         required: false


### PR DESCRIPTION
Changed Typo commmunity_nme to community_name