### PR TITLE
user (doc): Fix display of choices

### DIFF
--- a/plugins/modules/arubaoss_user.py
+++ b/plugins/modules/arubaoss_user.py
@@ -52,11 +52,11 @@ options:
         description:
             - type of password being conifgured
         required: true
-        choices: PET_PLAIN_TEXT, PET_SHA1
+        choices: [ PET_PLAIN_TEXT, PET_SHA1 ]
     state:
         description:
             - Enable or disable
-        choices: create, delete
+        choices: [create, delete ]
         default: create
         required: false
 


### PR DESCRIPTION
When use ansible-doc arubanetworks.aos_switch.arubaoss_user

you get the following display

```
= password_type
        type of password being conifgured
        (Choices: P, E, T, _, P, L, A, I, N, _, T, E, X, T, ,,  , P, E, T, _, S, H, A, 1)

- state
        Enable or disable
        (Choices: c, r, e, a, t, e, ,,  , d, e, l, e, t, e)[Default: create]
```
fix to have

```
= password_type
        type of password being conifgured
        (Choices: PET_PLAIN_TEXT, PET_SHA1)

- state
        Enable or disable
        (Choices: create, delete)[Default: create]
```
