### PR TITLE
Add support for pulling more data via the Facts module

### DIFF
--- a/plugins/module_utils/facts/facts.py
+++ b/plugins/module_utils/facts/facts.py
@@ -14,6 +14,7 @@ from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.int
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.legacy import Default, HostSystemInfo, \
     SwitchSpecificSystemInfo, Modules, PowerSupplies
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.vlans import VlansFacts
+from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.vlans_ports import VlansPortsFacts
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.acls import AclsFacts
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.lacp_interfaces import LacpInterfacesFacts
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.lldp_neighbors import LldpNeighborsFacts
@@ -31,6 +32,7 @@ FACT_LEGACY_SUBSETS = dict(
 
 FACT_RESOURCE_SUBSETS = dict(
     vlans=VlansFacts,
+    vlans_ports=VlansPortsFacts,
     interfaces=InterfacesFacts,
     acls=AclsFacts,
     lldp_neighbors=LldpNeighborsFacts,

--- a/plugins/module_utils/facts/facts.py
+++ b/plugins/module_utils/facts/facts.py
@@ -15,6 +15,9 @@ from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.leg
     SwitchSpecificSystemInfo, Modules, PowerSupplies
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.vlans import VlansFacts
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.vlans_ports import VlansPortsFacts
+from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.loop_protect_status import LoopProtectStatusFacts 
+from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.loop_protect_ports import LoopProtectPortsFacts 
+from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.loop_protect_vlans import LoopProtectVlansFacts 
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.acls import AclsFacts
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.lacp_interfaces import LacpInterfacesFacts
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.facts.lldp_neighbors import LldpNeighborsFacts
@@ -33,6 +36,9 @@ FACT_LEGACY_SUBSETS = dict(
 FACT_RESOURCE_SUBSETS = dict(
     vlans=VlansFacts,
     vlans_ports=VlansPortsFacts,
+    loop_protect_status = LoopProtectStatusFacts,
+    loop_protect_ports = LoopProtectPortsFacts,
+    loop_protect_vlans = LoopProtectVlansFacts,
     interfaces=InterfacesFacts,
     acls=AclsFacts,
     lldp_neighbors=LldpNeighborsFacts,

--- a/plugins/module_utils/facts/loop_protect_ports.py
+++ b/plugins/module_utils/facts/loop_protect_ports.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.arubaoss import get_config # NOQA
+import json # NOQA
+
+
+class LoopProtectPortsFacts(object):
+    '''
+    Loop Protect Ports Facts Class
+    '''
+
+    def __init__(self, module, subspec='config', options='options'):
+        '''
+        init function
+        '''
+        self._module = module
+
+    def populate_facts(self, connection, ansible_facts, data=None):
+        '''
+        Obtain and return Loop Protect Data
+        '''
+        url = '/loop_protect/ports'
+        check_presence = get_config(self._module, url)
+        if check_presence:
+          ports = json.loads(check_presence)
+
+        facts = {
+          'loop_protect_ports': ports
+        }
+        ansible_facts['ansible_network_resources'].update(facts)
+        return ansible_facts

--- a/plugins/module_utils/facts/loop_protect_status.py
+++ b/plugins/module_utils/facts/loop_protect_status.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.arubaoss import get_config # NOQA
+import json # NOQA
+
+
+class LoopProtectStatusFacts(object):
+    '''
+    Loop Protect Status Facts Class
+    '''
+
+    def __init__(self, module, subspec='config', options='options'):
+        '''
+        init function
+        '''
+        self._module = module
+
+    def populate_facts(self, connection, ansible_facts, data=None):
+        '''
+        Obtain and return Loop Protect Data
+        '''
+        url = '/loop_protect'
+        check_presence = get_config(self._module, url)
+        if check_presence:
+          status = json.loads(check_presence)
+
+        facts = {
+          'loop_protect_status': status
+        }
+        ansible_facts['ansible_network_resources'].update(facts)
+        return ansible_facts

--- a/plugins/module_utils/facts/loop_protect_vlans.py
+++ b/plugins/module_utils/facts/loop_protect_vlans.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.arubaoss import get_config # NOQA
+import json # NOQA
+
+
+class LoopProtectVlansFacts(object):
+    '''
+    Loop Protect Vlans Facts Class
+    '''
+
+    def __init__(self, module, subspec='config', options='options'):
+        '''
+        init function
+        '''
+        self._module = module
+
+    def populate_facts(self, connection, ansible_facts, data=None):
+        '''
+        Obtain and return Loop Protect Data
+        '''
+
+        url = '/loop_protect/vlans'
+        check_presence = get_config(self._module, url)
+        if check_presence:
+          vlans = json.loads(check_presence)
+
+        facts = {
+          'loop_protect_vlans': vlans
+        }
+        ansible_facts['ansible_network_resources'].update(facts)
+        return ansible_facts

--- a/plugins/module_utils/facts/vlans_ports.py
+++ b/plugins/module_utils/facts/vlans_ports.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.arubaoss import get_config # NOQA
+import json # NOQA
+
+
+class VlansPortsFacts(object):
+    '''
+    VLANs-Ports Facts Class
+    '''
+
+    def __init__(self, module, subspec='config', options='options'):
+        '''
+        init function
+        '''
+        self._module = module
+
+    def populate_facts(self, connection, ansible_facts, data=None):
+        '''
+        Obtain and return VLANs-Ports facts
+        '''
+        url = '/vlans-ports'
+        check_presence = get_config(self._module, url)
+        if check_presence:
+          vlans_ports = json.loads(check_presence)
+
+        facts = {
+            'vlans_ports': vlans_ports
+        }
+        ansible_facts['ansible_network_resources'].update(facts)
+        return ansible_facts

--- a/plugins/modules/arubaoss_facts.py
+++ b/plugins/modules/arubaoss_facts.py
@@ -52,8 +52,8 @@ options:
     description:
       - Retrieve vlan, interface, acl, lacp interfaces or lldp neighbors information.
         This can be a single category or it can be a list. Leaving this field blank
-        returns all interfaces, vlans, vlan-port assignments, acl, lacp interfaces and lldp neighbors.
-    choices: ['interfaces', 'vlans', 'vlans_ports', 'acls', 'lacp_interfaces', 'lldp_neighbors']
+        returns all interfaces, vlans, vlan-port assignments, loop protect status/ports/vlans, acl, lacp interfaces and lldp neighbors.
+    choices: ['interfaces', 'vlans', 'vlans_ports', 'loop_protect_status', 'loop_protect_ports', 'loop_protect_vlans', 'acls', 'lacp_interfaces', 'lldp_neighbors']
     required: False
     type: list
 
@@ -158,6 +158,7 @@ def main():
                                        'system_power_supply']),
         'gather_network_resources': dict(type='list',
                                          choices=['interfaces', 'vlans', 'vlans_ports',
+                                                  'loop_protect_status', 'loop_protect_ports', 'loop_protect_vlans',
                                                   'acls', 'lldp_neighbors',
                                                   'lacp_interfaces'])
     }

--- a/plugins/modules/arubaoss_facts.py
+++ b/plugins/modules/arubaoss_facts.py
@@ -52,8 +52,8 @@ options:
     description:
       - Retrieve vlan, interface, acl, lacp interfaces or lldp neighbors information.
         This can be a single category or it can be a list. Leaving this field blank
-        returns all interfaces, vlans, acl, lacp interfaces and lldp neighbors.
-    choices: ['interfaces', 'vlans', 'acls', 'lacp_interfaces', 'lldp_neighbors']
+        returns all interfaces, vlans, vlan-port assignments, acl, lacp interfaces and lldp neighbors.
+    choices: ['interfaces', 'vlans', 'vlans_ports', 'acls', 'lacp_interfaces', 'lldp_neighbors']
     required: False
     type: list
 
@@ -157,7 +157,7 @@ def main():
                                        'module_info',
                                        'system_power_supply']),
         'gather_network_resources': dict(type='list',
-                                         choices=['interfaces', 'vlans',
+                                         choices=['interfaces', 'vlans', 'vlans_ports',
                                                   'acls', 'lldp_neighbors',
                                                   'lacp_interfaces'])
     }


### PR DESCRIPTION
The facts module supports querying details about VLANs and ports.
However, there is no support for querying the VLAN-port mappings (`/vlans-ports` in the REST API).

This pull requests adds the `vlans_ports` option in `gather_network_resources`.