### PR TITLE
Fixes an issue where a binary string is returned 

### DIFF
--- a/plugins/modules/arubaoss_file_transfer.py
+++ b/plugins/modules/arubaoss_file_transfer.py
@@ -89,6 +89,7 @@ EXAMPLES = '''
 '''
 
 from ansible.module_utils.basic import AnsibleModule # NOQA
+from ansible.module_utils.common.text.converters import to_text
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.arubaoss import run_commands # NOQA
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.arubaoss import arubaoss_argument_spec # NOQA
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.arubaoss import get_config # NOQA
@@ -134,7 +135,7 @@ def transfer(module):
     if params['boot_image']:
         data['boot_image'] = params['boot_image']
     result = run_commands(module, url, data, 'POST')
-    message = result.get('body') or None
+    message = to_text(result.get('body')) or None
     if message and 'Another download is in progress' in message:
         result = {'changed': False}
         result['failed'] = True


### PR DESCRIPTION
This casues ansible to crash.

Thanks to @bcoca and @mackerman from #ansible on libera.chat :)

Also: 
I noticed that the default state of the file-transfer/status endpoint is FTS_COMPLETED even after a reboot, so if something goes wrong with starting the transfer that got passed over earlier in the code you get a situation where the module reports success even though it didn't do anything.

IIRC I triggered this by trying to "upload" a firmware image when the property should be "download" because the action runs from the switches' viewpoint, what happens then is:
1. the API will fail to "upload" a firmware image 
2. the module will continue to the next step because it only checks for 'another download in progress'
3. in the else loop where it checks the status it will immediately get FTS_COMPLETED even though no file transfer ever happened
4. success and a total time of 0 are returned

It seems to me that this is both an issue to be handled better on the ansible side but more importantly on the switch API side FTS_COMPLETED should only be asserted if a successful file transfer happened (and possibly even with a refernce number so that API clients can check that it is *their* transfer that succeeded and not some random transfer that happened just before/after they failed in their attempt.