### PR TITLE
arubaoss(cliconf): fix arguments-renamed

### DIFF
--- a/plugins/cliconf/arubaoss.py
+++ b/plugins/cliconf/arubaoss.py
@@ -42,7 +42,7 @@ class Cliconf(CliconfBase):
         super(Cliconf, self).__init__(*args, **kwargs)
 
     @enable_mode
-    def get_config(self, source='running', format='text', flags=None):
+    def get_config(self, source='running', flags=None, format='text'):
         '''
         Get the switch config
         '''


### PR DESCRIPTION
arubaoss.py:45:4: arguments-renamed: Parameter 'flags' has been renamed to 'format' in overridden 'Cliconf.get_config' method
arubaoss.py:45:4: arguments-renamed: Parameter 'format' has been renamed to 'flags' in overridden 'Cliconf.get_config' method