### PR TITLE
sanity: validate-modules : fix module-invalid-version-added

### DIFF
--- a/plugins/cliconf/arubaoss.py
+++ b/plugins/cliconf/arubaoss.py
@@ -13,7 +13,7 @@ network_cli: arubaoss
 short_description: Use CLI to run commands to Switch devices
 description:
   - This AOS-Switch plugin provides CLI operations with ArubaOS-Switch Devices
-version_added: "2.9"
+version_added: "2.9.0"
 """
 
 import json  # NOQA

--- a/plugins/modules/arubaoss_aaa_authentication.py
+++ b/plugins/modules/arubaoss_aaa_authentication.py
@@ -30,7 +30,7 @@ module: arubaoss_aaa_authentication
 
 short_description: implements rest api for AAA Authentication configuration
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apis which can be used to configure authentication"

--- a/plugins/modules/arubaoss_aaa_authorization.py
+++ b/plugins/modules/arubaoss_aaa_authorization.py
@@ -30,7 +30,7 @@ module: arubaoss_aaa_authorization
 
 short_description: implements rest api for AAA Authorization configuration
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apis which can be used to configure authorization"

--- a/plugins/modules/arubaoss_acl_policy.py
+++ b/plugins/modules/arubaoss_acl_policy.py
@@ -30,7 +30,7 @@ module: arubaoss_acl_policy
 
 short_description: implements rest api for global acl configuration
 
-version_added: "2.6"
+version_added: "2.6.0"
 
 description:
     - "This implements rest api's which will configure acl policies

--- a/plugins/modules/arubaoss_anycli.py
+++ b/plugins/modules/arubaoss_anycli.py
@@ -30,7 +30,7 @@ module: arubaoss_anycli
 
 short_description: implements rest api to execute CLI command via anyCLI uri
 
-version_added: "2.10"
+version_added: "2.10.0"
 
 description:
     - "This implements rest apis which can be used to support anyCLI"

--- a/plugins/modules/arubaoss_captive_portal.py
+++ b/plugins/modules/arubaoss_captive_portal.py
@@ -30,7 +30,7 @@ module: arubaoss_captive_portal
 
 short_description: Implements Ansible module for captive portal configuration.
 
-version_added: "2.6"
+version_added: "2.6.0"
 
 description:
     - "This implement rest api's which can be used to configure captive portal

--- a/plugins/modules/arubaoss_command.py
+++ b/plugins/modules/arubaoss_command.py
@@ -17,7 +17,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: arubaoss_command
-version_added: "2.9"
+version_added: "2.9.0"
 short_description: Logs in and executes CLI commands on AOS-Switch device via SSH connection
 description:
   - This module allows execution of CLI commands on AOS-Switch devices via SSH connection

--- a/plugins/modules/arubaoss_config.py
+++ b/plugins/modules/arubaoss_config.py
@@ -18,7 +18,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: arubaoss_config
-version_added: "2.9"
+version_added: "2.9.0"
 short_description: Logs in and executes configuration commands on AOS-Switch device via SSH connection
 description:
   - This module allows configuration of running-configs on AOS-Switch devices via SSH connection

--- a/plugins/modules/arubaoss_config_bkup.py
+++ b/plugins/modules/arubaoss_config_bkup.py
@@ -31,7 +31,7 @@ module: arubaoss_config_bkup
 short_description: Implements Ansible module for switch configuration
                    backup and restore.
 
-version_added: "2.6"
+version_added: "2.6.0"
 
 description:
     - "This implement rest api's which can be used to backup switch

--- a/plugins/modules/arubaoss_dns.py
+++ b/plugins/modules/arubaoss_dns.py
@@ -30,7 +30,7 @@ module: arubaoss_dns
 
 short_description: implements rest api for DNS configuration
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apis which can be used to configure DNS"

--- a/plugins/modules/arubaoss_dot1x.py
+++ b/plugins/modules/arubaoss_dot1x.py
@@ -30,7 +30,7 @@ module: arubaoss_dot1x
 
 short_description: implements rest api for DOT1x configuration
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apis which can be used to configure DOT1x"

--- a/plugins/modules/arubaoss_dsnoop.py
+++ b/plugins/modules/arubaoss_dsnoop.py
@@ -30,7 +30,7 @@ module: arubaoss_dsnoop
 
 short_description: implements REST API for DHCP snooping
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements REST APIs which can be used to configure DHCP snooping"

--- a/plugins/modules/arubaoss_facts.py
+++ b/plugins/modules/arubaoss_facts.py
@@ -28,7 +28,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: arubaoss_facts
-version_added: "2.10"
+version_added: "2.10.0"
 short_description: Collects facts from remote PVOS device
 description:
   - This module retrieves facts from Aruba devices running the PVOS operating system.

--- a/plugins/modules/arubaoss_file_transfer.py
+++ b/plugins/modules/arubaoss_file_transfer.py
@@ -30,7 +30,7 @@ module: arubaoss_file_transfer
 
 short_description: implements rest api's for file transfer from/to device
 
-version_added: "2.6"
+version_added: "2.6.0"
 
 description:
     - "This implements rest api's for file transfer from/to device. The

--- a/plugins/modules/arubaoss_interface.py
+++ b/plugins/modules/arubaoss_interface.py
@@ -31,7 +31,7 @@ module: arubaoss_interface
 short_description: Implements Ansible module for port configuration
                    and management.
 
-version_added: "2.6"
+version_added: "2.6.0"
 
 description:
     - "This implement rest api's which can be used to configure ports"

--- a/plugins/modules/arubaoss_ip_auth.py
+++ b/plugins/modules/arubaoss_ip_auth.py
@@ -30,7 +30,7 @@ module: arubaoss_ip_auth
 
 short_description: implements rest api for ip authorization
 
-version_added: "2.6"
+version_added: "2.6.0"
 
 description:
     - "This implements rest api's which configure ip autorization on device"

--- a/plugins/modules/arubaoss_ip_route.py
+++ b/plugins/modules/arubaoss_ip_route.py
@@ -30,7 +30,7 @@ module: arubaoss_ip_route
 
 short_description: implements rest api for static routing
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements static routing rest api and global routing

--- a/plugins/modules/arubaoss_loop_protect.py
+++ b/plugins/modules/arubaoss_loop_protect.py
@@ -30,7 +30,7 @@ module: arubaoss_loop_protect
 
 short_description: implements loop-protect rest api
 
-version_added: "2.6"
+version_added: "2.6.0"
 
 description:
     - "This configures loop protect on device over vlan or port"

--- a/plugins/modules/arubaoss_mac_authentication.py
+++ b/plugins/modules/arubaoss_mac_authentication.py
@@ -30,7 +30,7 @@ module: arubaoss_mac_authentication
 
 short_description: implements rest api for Mac Authentication
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apis which can be used to configure

--- a/plugins/modules/arubaoss_ntp.py
+++ b/plugins/modules/arubaoss_ntp.py
@@ -30,7 +30,7 @@ module: arubaoss_ntp
 
 short_description: implements rest api for NTP configuration
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apis which can be used to configure NTP"

--- a/plugins/modules/arubaoss_poe.py
+++ b/plugins/modules/arubaoss_poe.py
@@ -30,7 +30,7 @@ module: arubaoss_poe
 
 short_description: implements rest api for PoE configuration
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apis which can be used to configure PoE"

--- a/plugins/modules/arubaoss_port_rate_limit.py
+++ b/plugins/modules/arubaoss_port_rate_limit.py
@@ -30,7 +30,7 @@ module: arubaoss_port_rate_limit
 
 short_description: implements rest api for AAA Accounting configuration
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apis which can be used to configure AAA Accounting"

--- a/plugins/modules/arubaoss_qos_policy.py
+++ b/plugins/modules/arubaoss_qos_policy.py
@@ -30,7 +30,7 @@ module: arubaoss_qos_policy
 
 short_description: implements rest api for qos configuration
 
-version_added: "2.6"
+version_added: "2.6.0"
 
 description:
     - "This implements rest api's which can be used to configure qos

--- a/plugins/modules/arubaoss_radius_profile.py
+++ b/plugins/modules/arubaoss_radius_profile.py
@@ -30,7 +30,7 @@ module: arubaoss_radius_profile
 
 short_description: implements rest api for aaa configuration
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apis which can be used to configure RADIUS Server"

--- a/plugins/modules/arubaoss_reboot.py
+++ b/plugins/modules/arubaoss_reboot.py
@@ -30,7 +30,7 @@ module: arubaoss_reboot
 
 short_description: reboots the device
 
-version_added: "2.6"
+version_added: "2.6.0"
 
 description:
     - "This reboots the device and waits until it comes up.

--- a/plugins/modules/arubaoss_routing.py
+++ b/plugins/modules/arubaoss_routing.py
@@ -30,7 +30,7 @@ module: arubaoss_routing
 
 short_description: implements rest api for routing
 
-version_added: "2.6"
+version_added: "2.6.0"
 
 description:
     - "This implements routing rest api to enable/disable routing on device"

--- a/plugins/modules/arubaoss_snmp.py
+++ b/plugins/modules/arubaoss_snmp.py
@@ -30,7 +30,7 @@ module: arubaoss_snmp
 
 short_description: implements rest api for snmp configuration
 
-version_added: "2.6"
+version_added: "2.6.0"
 
 description:
     - "This implements rest api's which configure snmp on device"

--- a/plugins/modules/arubaoss_snmp_trap.py
+++ b/plugins/modules/arubaoss_snmp_trap.py
@@ -30,7 +30,7 @@ module: arubaoss_snmp_trap
 
 short_description: implements rest api for snmp trap configuration
 
-version_added: "2.6"
+version_added: "2.6.0"
 
 description:
     - "This implements rest api's which enable/disable snmp traps for

--- a/plugins/modules/arubaoss_sntp.py
+++ b/plugins/modules/arubaoss_sntp.py
@@ -32,7 +32,7 @@ module: arubaoss_sntp
 short_description: implements rest api for sntp and sntp server
                    priority configuration
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apis which can be used to configure sntp"

--- a/plugins/modules/arubaoss_stp.py
+++ b/plugins/modules/arubaoss_stp.py
@@ -30,7 +30,7 @@ module: arubaoss_stp
 
 short_description: implements rest api for stp configuration
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apis which can be used to configure STP"

--- a/plugins/modules/arubaoss_syslog.py
+++ b/plugins/modules/arubaoss_syslog.py
@@ -30,7 +30,7 @@ module: arubaoss_syslog
 
 short_description: implements rest api for syslog configuration
 
-version_added: "2.6"
+version_added: "2.6.0"
 
 description:
     - "This implements rest api's which configure syslog on device"

--- a/plugins/modules/arubaoss_system_attributes.py
+++ b/plugins/modules/arubaoss_system_attributes.py
@@ -30,7 +30,7 @@ module: arubaoss_system_attributes
 
 short_description: implements rest api for system attributes
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apis which can be used to configure system attributes"

--- a/plugins/modules/arubaoss_tacacs_profile.py
+++ b/plugins/modules/arubaoss_tacacs_profile.py
@@ -30,7 +30,7 @@ module: arubaoss_tacacs_profile
 
 short_description: implements rest api for TACACS configuration
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apis which can be used to configure TACACS Server"

--- a/plugins/modules/arubaoss_traffic_class.py
+++ b/plugins/modules/arubaoss_traffic_class.py
@@ -30,7 +30,7 @@ module: arubaoss_interfaces
 
 short_description: implements rest api for traffic class configuration
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apiis whcih can be used to configure trafic class"

--- a/plugins/modules/arubaoss_user.py
+++ b/plugins/modules/arubaoss_user.py
@@ -31,7 +31,7 @@ module: arubaoss_user
 short_description: Implements Ansible module for configuring and
                    managing user on device.
 
-version_added: "2.6"
+version_added: "2.6.0"
 
 description:
     - "This implement rest api's which can be use to manage and configure

--- a/plugins/modules/arubaoss_vlan.py
+++ b/plugins/modules/arubaoss_vlan.py
@@ -30,7 +30,7 @@ module: arubaoss_vlan
 
 short_description: implements rest api for vlan configuration
 
-version_added: "2.4"
+version_added: "2.4.0"
 
 description:
     - "This implements rest apis which can be used to configure vlan"


### PR DESCRIPTION
module-invalid-version-added: DOCUMENTATION: version_added ('2.6') is not a valid collection version (see specification at https://semver.org/): invalid semantic version '2.6'.