### PR TITLE
fix for dns configuration check on switch

### DIFF
--- a/plugins/modules/arubaoss_ntp.py
+++ b/plugins/modules/arubaoss_ntp.py
@@ -520,9 +520,8 @@ def config_ntp_ipv4addr(module):
     except Exception:
         check_presence = get_config(module, "/dns")
         newdata = json.loads(check_presence)
-        value = [newdata["server_1"], newdata["server_2"], newdata["server_3"],
-                 newdata["server_4"]]
-        if value.count(None) == 4:
+        value = [ newdata[x] for x in newdata if "server_" in x ]
+        if value.count(None) == len(value):
             return {
                 'msg': 'A DNS server must be configured before configuring '
                 'NTP unicast server name', 'changed': False, 'failed': True}


### PR DESCRIPTION
resolves #56 

The code checking the presence of a DNS would expect the '/dns' request to return a set number of 4 `server_x` values when it would sometimes return 2 or 1. This fixes it by using a list comprehension to get all possible values and checking if at least 1 is not none.