### PR TITLE
ntp: fix pep8 warnings

### DIFF
--- a/plugins/modules/arubaoss_ntp.py
+++ b/plugins/modules/arubaoss_ntp.py
@@ -641,7 +641,7 @@ def config_ntp_ipv4addr(module):
     except Exception:
         check_presence = get_config(module, "/dns")
         newdata = json.loads(check_presence)
-        value = [ newdata[x] for x in newdata if "server_" in x ]
+        value = [newdata[x] for x in newdata if "server_" in x]
         if value.count(None) == len(value):
             return {
                 'msg': 'A DNS server must be configured before configuring '


### PR DESCRIPTION
ERROR: plugins/modules/arubaoss_ntp.py:681:18: E201: whitespace after '['
ERROR: plugins/modules/arubaoss_ntp.py:681:64: E202: whitespace before ']'