### PR TITLE
Migrate `warnings` key in `exit_json` to AnsibleModule.warn

### DIFF
--- a/plugins/module_utils/arubaoss.py
+++ b/plugins/module_utils/arubaoss.py
@@ -84,10 +84,6 @@ def get_provider_argspec():
     return arubaoss_provider_spec
 
 
-def check_args(module, warnings):
-    pass
-
-
 class Checkversion:
     '''
     Here we set default REST API version as v6.0 to login &

--- a/plugins/module_utils/facts/facts.py
+++ b/plugins/module_utils/facts/facts.py
@@ -70,4 +70,4 @@ class Facts(FactsBase):
             self.get_network_legacy_facts(FACT_LEGACY_SUBSETS,
                                           legacy_facts_type)
 
-        return self.ansible_facts, self._warnings
+        return self.ansible_facts

--- a/plugins/module_utils/facts/legacy.py
+++ b/plugins/module_utils/facts/legacy.py
@@ -20,7 +20,6 @@ class FactsBase(object):
 
     def __init__(self, module):
         self._module = module
-        self.warnings = list()
         self.facts = dict()
         self.responses = None
         self._url = None

--- a/plugins/modules/arubaoss_aaa_accounting.py
+++ b/plugins/modules/arubaoss_aaa_accounting.py
@@ -294,7 +294,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_aaa_authentication.py
+++ b/plugins/modules/arubaoss_aaa_authentication.py
@@ -483,7 +483,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_aaa_authorization.py
+++ b/plugins/modules/arubaoss_aaa_authorization.py
@@ -354,7 +354,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_acl_policy.py
+++ b/plugins/modules/arubaoss_acl_policy.py
@@ -780,7 +780,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_anycli.py
+++ b/plugins/modules/arubaoss_anycli.py
@@ -233,7 +233,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_captive_portal.py
+++ b/plugins/modules/arubaoss_captive_portal.py
@@ -252,7 +252,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_command.py
+++ b/plugins/modules/arubaoss_command.py
@@ -254,7 +254,7 @@ def transform_commands(module):
     return transform(module.params['commands'])
 
 
-def parse_commands(module, warnings):
+def parse_commands(module):
     '''
     Parse the command
     '''
@@ -279,15 +279,13 @@ def main():
 
     argument_spec.update(arubaoss_argument_spec)
 
-    warnings = list()
-
-    result = {'changed': False, 'warnings': warnings}
+    result = {'changed': False}
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True
     )
 
-    commands = parse_commands(module, warnings)
+    commands = parse_commands(module)
     wait_for = module.params['wait_for'] or list()
 
     try:

--- a/plugins/modules/arubaoss_config.py
+++ b/plugins/modules/arubaoss_config.py
@@ -335,7 +335,6 @@ from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.arubaoss 
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.arubaoss import run_cli_commands as run_commands  # NOQA
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.arubaoss import arubaoss_argument_spec  # NOQA
 from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.arubaoss import get_cli_config as get_config  # NOQA
-from ansible_collections.arubanetworks.aos_switch.plugins.module_utils.arubaoss import check_args as arubaoss_check_args  # NOQA
 from ansible.module_utils.basic import AnsibleModule  # NOQA
 try:
     from ansible.module_utils.network.common.config import NetworkConfig, dumps  # NOQA
@@ -431,9 +430,7 @@ def main():
                            required_if=required_if,
                            supports_check_mode=True)
 
-    warnings = list()
-    arubaoss_check_args(module, warnings)
-    result = {'changed': False, 'warnings': warnings}
+    result = {'changed': False}
 
     config = None
 

--- a/plugins/modules/arubaoss_config_bkup.py
+++ b/plugins/modules/arubaoss_config_bkup.py
@@ -386,7 +386,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_dns.py
+++ b/plugins/modules/arubaoss_dns.py
@@ -382,7 +382,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_dot1x.py
+++ b/plugins/modules/arubaoss_dot1x.py
@@ -613,7 +613,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_dsnoop.py
+++ b/plugins/modules/arubaoss_dsnoop.py
@@ -363,7 +363,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_facts.py
+++ b/plugins/modules/arubaoss_facts.py
@@ -211,14 +211,9 @@ def main():
 
     module._connection = get_connection(module)  # NOQA
 
-    warnings = []
+    ansible_facts = Facts(module).get_facts()
 
-    result = Facts(module).get_facts()
-
-    ansible_facts, additional_warnings = result
-    warnings.extend(additional_warnings)
-
-    module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
+    module.exit_json(ansible_facts=ansible_facts)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/arubaoss_file_transfer.py
+++ b/plugins/modules/arubaoss_file_transfer.py
@@ -311,7 +311,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_interface.py
+++ b/plugins/modules/arubaoss_interface.py
@@ -357,7 +357,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_ip_auth.py
+++ b/plugins/modules/arubaoss_ip_auth.py
@@ -288,7 +288,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_ip_route.py
+++ b/plugins/modules/arubaoss_ip_route.py
@@ -373,7 +373,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_lacp.py
+++ b/plugins/modules/arubaoss_lacp.py
@@ -221,7 +221,7 @@ def run_module():
     )
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_loop_protect.py
+++ b/plugins/modules/arubaoss_loop_protect.py
@@ -315,7 +315,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_mac_authentication.py
+++ b/plugins/modules/arubaoss_mac_authentication.py
@@ -311,7 +311,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_poe.py
+++ b/plugins/modules/arubaoss_poe.py
@@ -394,7 +394,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_qos_policy.py
+++ b/plugins/modules/arubaoss_qos_policy.py
@@ -368,7 +368,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_radius_profile.py
+++ b/plugins/modules/arubaoss_radius_profile.py
@@ -515,7 +515,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_reboot.py
+++ b/plugins/modules/arubaoss_reboot.py
@@ -251,7 +251,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_snmp.py
+++ b/plugins/modules/arubaoss_snmp.py
@@ -481,7 +481,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_snmp_trap.py
+++ b/plugins/modules/arubaoss_snmp_trap.py
@@ -451,7 +451,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_sntp.py
+++ b/plugins/modules/arubaoss_sntp.py
@@ -378,7 +378,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_stp.py
+++ b/plugins/modules/arubaoss_stp.py
@@ -329,7 +329,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_syslog.py
+++ b/plugins/modules/arubaoss_syslog.py
@@ -273,7 +273,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_system_attributes.py
+++ b/plugins/modules/arubaoss_system_attributes.py
@@ -305,7 +305,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_tacacs_profile.py
+++ b/plugins/modules/arubaoss_tacacs_profile.py
@@ -366,7 +366,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_traffic_class.py
+++ b/plugins/modules/arubaoss_traffic_class.py
@@ -534,7 +534,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_user.py
+++ b/plugins/modules/arubaoss_user.py
@@ -291,7 +291,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,

--- a/plugins/modules/arubaoss_vlan.py
+++ b/plugins/modules/arubaoss_vlan.py
@@ -796,7 +796,7 @@ def run_module():
 
     module_args.update(arubaoss_argument_spec)
 
-    result = dict(changed=False, warnings='Not Supported')
+    result = {"changed": False}
 
     module = AnsibleModule(
         argument_spec=module_args,


### PR DESCRIPTION
This commit should update the remaining modules that do not already use the `AnsibleModule.warn` method for raising warnings instead of the deprecated practice of passing a warnings key to exit_json (see #100)